### PR TITLE
Create pid directory if not exist

### DIFF
--- a/templates/init.Debian
+++ b/templates/init.Debian
@@ -98,6 +98,13 @@ daemon={{influxdb_bin_file}}
 # pid file for the daemon
 pidfile={{influxdb_pid_file}}
 
+# Create PIDDIR on runtime
+if [ ! -d {{influxdb_run_dir}} ];
+then
+  mkdir {{influxdb_run_dir}}
+  chown {{influxdb_user}} {{influxdb_run_dir}}
+fi
+
 # Configuration file
 config={{influxdb_conf_file}}
 


### PR DESCRIPTION
If pid directory doesn't exist start fail, adding verification and creation of pid directory.
(like in mysql init.d script for example)
